### PR TITLE
Split back end logic into a library project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin
 obj
+*.suo

--- a/DumpKinectSkeleton.sln
+++ b/DumpKinectSkeleton.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DumpKinectSkeleton", "DumpKinectSkeleton.csproj", "{3E5326BA-8A39-40B4-A46B-AE23998F1737}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DumpKinectSkeletonLib", "DumpKinectSkeletonLib\DumpKinectSkeletonLib.csproj", "{A03A0C74-7E96-4BAF-80C3-28E1D4CAE35E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{3E5326BA-8A39-40B4-A46B-AE23998F1737}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E5326BA-8A39-40B4-A46B-AE23998F1737}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E5326BA-8A39-40B4-A46B-AE23998F1737}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A03A0C74-7E96-4BAF-80C3-28E1D4CAE35E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A03A0C74-7E96-4BAF-80C3-28E1D4CAE35E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A03A0C74-7E96-4BAF-80C3-28E1D4CAE35E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A03A0C74-7E96-4BAF-80C3-28E1D4CAE35E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DumpKinectSkeletonLib/BodyFrameDumper.cs
+++ b/DumpKinectSkeletonLib/BodyFrameDumper.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Microsoft.Kinect;
+
+namespace DumpKinectSkeletonLib
+{
+    public class BodyFrameDumper
+    {
+        /// <summary>
+        /// Body output file stream.
+        /// </summary>
+        private StreamWriter _bodyOutputStream;
+
+        /// <summary>
+        /// Array buffer for tracked bodies.
+        /// </summary>
+        private Body[] _bodies;
+
+        /// <summary>
+        /// Number of currently tracked bodies.
+        /// </summary>
+        public int BodyCount { get; private set; }
+
+        public TimeSpan InitialTime;
+
+        /// <summary>
+        /// Create a new body frame dumper that dumps first tracked Body data to a csv file.
+        /// </summary>
+        /// <param name="kinectSource"></param>
+        /// <param name="outputFileName"></param>
+        public BodyFrameDumper( KinectSource kinectSource, string outputFileName )
+        {
+            // open file for output
+            try
+            {
+                _bodyOutputStream = new StreamWriter( new BufferedStream( new FileStream( outputFileName, FileMode.Create ) ) );
+
+                // write header
+                _bodyOutputStream.WriteLine(
+                    "# timestamp, jointType, position.X, position.Y, position.Z, orientation.X, orientation.Y, orientation.Z, orientation.W, state" );
+            }
+            catch ( Exception e )
+            {
+                Console.Error.WriteLine( "Error opening output file: " + e.Message );
+                Close();
+                throw;
+            }
+            kinectSource.BodyFrameEvent += HandleBodyFrame;
+            kinectSource.FirstFrameRelativeTimeEvent += ts => InitialTime = ts;
+        }
+
+        /// <summary>
+        /// Close subjacent output streams
+        /// </summary>
+        public void Close()
+        {
+            BodyCount = 0;
+            _bodyOutputStream?.Close();
+            _bodyOutputStream = null;
+        }
+
+        /// <summary>
+        /// Handle a BodyFrame. Dumps first tracked Body to output file.
+        /// </summary>
+        /// <param name="frame"></param>
+        public void HandleBodyFrame( BodyFrame frame )
+        {
+            // throw an error is dumper has been closed or output stream could not be opened or written to.
+            if ( _bodyOutputStream == null )
+            {
+                throw new InvalidOperationException( "BodyFrameDumper is closed." );
+            }
+            var time = frame.RelativeTime;
+
+            // lazy body buffer initialization
+            if ( _bodies == null )
+            {
+                _bodies = new Body[ frame.BodyCount ];
+            }
+            
+            // The first time GetAndRefreshBodyData is called, Kinect will allocate each Body in the array.
+            // As long as those body objects are not disposed and not set to null in the array,
+            // those body objects will be re-used.
+            frame.GetAndRefreshBodyData( _bodies );
+
+            // read the tracking state of bodies
+            BodyCount = 0;
+            Body firstBody = null;
+            foreach ( var body in _bodies.Where( body => body.IsTracked ) )
+            {
+                BodyCount++;
+                if ( firstBody == null )
+                {
+                    firstBody = body;
+                }
+            }
+
+            // dump first tracked body
+            if ( BodyCount > 0 )
+            {
+                try
+                {
+                    OutputBody( time - InitialTime, firstBody );
+                }
+                catch ( Exception e )
+                {
+                    Console.Error.WriteLine( "Error writing to output file(s): " + e.Message );
+                    Close();
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Output skeleton data to output file as [timestamp, jointType, position.X, position.Y, position.Z, orientation.X, orientation.Y, orientation.Z, orientation.W, state].
+        /// </summary>
+        /// <param name="timestamp"></param>
+        /// <param name="body"></param>
+        private void OutputBody( TimeSpan timestamp, Body body )
+        {
+            var joints = body.Joints;
+            var orientations = body.JointOrientations;
+
+            // see https://msdn.microsoft.com/en-us/library/microsoft.kinect.jointtype.aspx for jointType Description
+            foreach ( var jointType in joints.Keys )
+            {
+                var position = joints[ jointType ].Position;
+                var orientation = orientations[ jointType ].Orientation;
+                _bodyOutputStream.WriteLine( string.Format( CultureInfo.InvariantCulture.NumberFormat,
+                    "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}",
+                    timestamp.TotalMilliseconds,
+                    (int)jointType,
+                    position.X, position.Y, position.Z,
+                    orientation.X, orientation.Y, orientation.Z, orientation.W,
+                    (int)joints[ jointType ].TrackingState ) );
+            }
+        }
+    }
+}

--- a/DumpKinectSkeletonLib/ColorFrameDumper.cs
+++ b/DumpKinectSkeletonLib/ColorFrameDumper.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.IO;
+using Microsoft.Kinect;
+
+namespace DumpKinectSkeletonLib
+{
+    public class ColorFrameDumper
+    {
+        /// <summary>
+        /// Array storing latest color frame pixels.
+        /// </summary>
+        private byte[] _colorFrameBytes;
+
+        /// <summary>
+        /// Color frames output file stream.
+        /// </summary>
+        private Stream _colorOutputStream;
+
+        public ColorFrameDumper( KinectSource kinectSource, string colorDataOutputFile )
+        {
+            // open file for output
+            try
+            {
+                _colorOutputStream = new BufferedStream( new FileStream( colorDataOutputFile, FileMode.Create ) );
+            }
+            catch ( Exception e )
+            {
+                Console.Error.WriteLine( "Error opening output file: " + e.Message );
+                Close();
+                throw;
+            }
+            kinectSource.ColorFrameEvent += HandleColorFrame;
+        }
+
+        /// <summary>
+        /// Close subjacent output streams
+        /// </summary>
+        public void Close()
+        {
+            _colorOutputStream?.Close();
+            _colorOutputStream = null;
+        }
+
+        /// <summary>
+        /// Handle a ColorFrame. Dumps the frame in raw kinect YUY2 format.
+        /// </summary>
+        /// <param name="frame"></param>
+        public void HandleColorFrame( ColorFrame frame )
+        {
+            // throw an error is dumper has been closed or output stream could not be opened or written to.
+            if ( _colorOutputStream == null )
+            {
+                throw new InvalidOperationException( "ColorFrameDumper is closed." );
+            }
+            // lazy color frame buffer initialization
+            if ( _colorFrameBytes == null )
+            {
+                _colorFrameBytes =
+                    new byte[ frame.FrameDescription.LengthInPixels * frame.FrameDescription.BytesPerPixel ];
+            }
+
+            if ( frame.RawColorImageFormat != ColorImageFormat.Yuy2 )
+            {
+                frame.CopyConvertedFrameDataToArray( _colorFrameBytes, ColorImageFormat.Yuy2 );
+            }
+            else
+            {
+                frame.CopyRawFrameDataToArray( _colorFrameBytes );
+            }
+
+            try
+            {
+                _colorOutputStream.Write( _colorFrameBytes, 0, _colorFrameBytes.Length );
+            }
+            catch ( Exception e )
+            {
+                Console.Error.WriteLine( "Error writing to output file(s): " + e.Message );
+                Close();
+                throw;
+            }
+        }        
+    }
+}

--- a/DumpKinectSkeletonLib/DumpKinectSkeletonLib.csproj
+++ b/DumpKinectSkeletonLib/DumpKinectSkeletonLib.csproj
@@ -1,20 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{3E5326BA-8A39-40B4-A46B-AE23998F1737}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <ProjectGuid>{A03A0C74-7E96-4BAF-80C3-28E1D4CAE35E}</ProjectGuid>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>DumpKinectSkeleton</RootNamespace>
-    <AssemblyName>DumpKinectSkeleton</AssemblyName>
+    <RootNamespace>DumpKinectSkeletonLib</RootNamespace>
+    <AssemblyName>DumpKinectSkeletonLib</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -22,49 +21,32 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <HintPath>packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Kinect, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files\Microsoft SDKs\Kinect\v2.0_1409\Assemblies\Microsoft.Kinect.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.Kinect, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Program.cs" />
+    <Compile Include="BodyFrameDumper.cs" />
+    <Compile Include="ColorFrameDumper.cs" />
+    <Compile Include="FpsWatch.cs" />
+    <Compile Include="KinectSource.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="DumpKinectSkeletonLib\DumpKinectSkeletonLib.csproj">
-      <Project>{a03a0c74-7e96-4baf-80c3-28e1d4cae35e}</Project>
-      <Name>DumpKinectSkeletonLib</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/DumpKinectSkeletonLib/FpsWatch.cs
+++ b/DumpKinectSkeletonLib/FpsWatch.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace DumpKinectSkeletonLib
+{
+    internal class FpsWatch
+    {
+        private readonly double _updatePerdiod;
+
+        public double Value { get; private set; }
+        
+        private int _frameCount;
+        private DateTime _timeLastReset;
+
+        public FpsWatch( double updatePerdiod )
+        {
+            _updatePerdiod = updatePerdiod;
+        }
+
+        public void Tick()
+        {
+            _frameCount++;
+            var timeSinceLastReset = ( DateTime.Now - _timeLastReset ).TotalSeconds;
+            if ( timeSinceLastReset >= _updatePerdiod )
+            {
+                Value = _frameCount / timeSinceLastReset;
+                Reset();
+            }
+        }
+
+        public void Reset()
+        {
+            _frameCount = 0;
+            _timeLastReset = DateTime.Now;
+        }        
+    }
+}

--- a/DumpKinectSkeletonLib/KinectSource.cs
+++ b/DumpKinectSkeletonLib/KinectSource.cs
@@ -1,0 +1,356 @@
+﻿using System;
+using Microsoft.Kinect;
+
+namespace DumpKinectSkeletonLib
+{
+    public class KinectSource
+    {
+        /// <summary>
+        /// Active Kinect sensor
+        /// </summary>
+        private readonly KinectSensor _kinectSensor;
+
+        /// <summary>
+        /// Reader for multi sources sync'ed frames
+        /// </summary>
+        private MultiSourceFrameReader _multiFrameReader;
+
+        /// <summary>
+        /// Reader for non sync'ed body frames
+        /// </summary>
+        private BodyFrameReader _bodyFrameReader;
+
+        /// <summary>
+        /// Reader for non sync'ed color frames
+        /// </summary>
+        private ColorFrameReader _colorFrameReader;
+
+        public bool FrameSync { get; set; }
+
+        /// <summary>
+        /// Compute body stream frame rate.
+        /// </summary>
+        private readonly FpsWatch _bodySourceFpsWatcher = new FpsWatch( 1 );
+
+        /// <summary>
+        /// Get the skeleton stream frame rate.
+        /// </summary>
+        public double BodySourceFps
+        {
+            get { return _bodySourceFpsWatcher.Value; }
+        }
+
+        /// <summary>
+        /// Compute color stream frame rate.
+        /// </summary>
+        private readonly FpsWatch _colorSourceFpsWatcher = new FpsWatch( 1 );
+
+        /// <summary>
+        /// Get the color stream frame rate.
+        /// </summary>
+        public double ColorSourceFps
+        {
+            get { return _colorSourceFpsWatcher.Value; }
+        }
+
+        public FrameDescription ColorFrameDescription
+        {
+            get { return _kinectSensor.ColorFrameSource.FrameDescription; }
+        }
+
+        /// <summary>
+        /// First Frame RelativeTime event handler delegate.
+        /// </summary>
+        public delegate void FirstFrameRelativeTimeEventHandler( TimeSpan firstRelativeTime );
+
+        private bool _firstFrameRelativeTimeEventFired;
+        private bool _kinectUsedExternally = false;
+        public event FirstFrameRelativeTimeEventHandler FirstFrameRelativeTimeEvent;
+
+        /// <summary>
+        /// Frame processing exception event handler delegate.
+        /// </summary>
+        /// <param name="exception"></param>
+        public delegate void FrameProcessExceptionEventHandler( Exception exception );
+
+        /// <summary>
+        /// Event fired when an exception occured during frames processing.
+        /// </summary>
+        public event FrameProcessExceptionEventHandler FrameProcessExceptionEvent;
+
+        /// <summary>
+        /// Body frame processor event handler
+        /// </summary>
+        /// <param name="frame"></param>
+        public delegate void BodyFrameEventHandler( BodyFrame frame );
+
+        /// <summary>
+        /// Event fired when a body frame is captured.
+        /// </summary>
+        public event BodyFrameEventHandler BodyFrameEvent;
+
+        /// <summary>
+        /// Color frame processor event handler
+        /// </summary>
+        /// <param name="frame"></param>
+        public delegate void ColorFrameEventHandler( ColorFrame frame );
+
+        /// <summary>
+        /// Event fired when a color frame is captured.
+        /// </summary>
+        public event ColorFrameEventHandler ColorFrameEvent;
+
+        /// <summary>
+        /// Create a new kinect source, initialize Kinect sensor with one multi frame reader.
+        /// </summary>
+        public KinectSource()
+        {
+            _kinectSensor = KinectSensor.GetDefault();
+            CheckSensor();
+        }
+
+        public KinectSource(KinectSensor sensor)
+        {
+            _kinectSensor = sensor;
+            _kinectUsedExternally = true;
+            CheckSensor();
+        }
+
+        private void CheckSensor()
+        {
+            if (_kinectSensor == null)
+            {
+                Close();
+                throw new ApplicationException("Error getting Kinect Sensor.");
+            }
+        }
+        
+        private void OnFirstFrameRelativeTimeEvent( TimeSpan firstRelativeTime )
+        {
+            if ( FirstFrameRelativeTimeEvent != null )
+            {
+                FirstFrameRelativeTimeEvent( firstRelativeTime );
+                _firstFrameRelativeTimeEventFired = true;
+            }
+        }
+
+        /// <summary>
+        /// Handles the body frame data arriving from the multi frame reader.
+        /// Dispatch each frames to corresponding processors and Dispose them.
+        /// </summary>
+        /// <param name="sender">object sending the event</param>
+        /// <param name="evt">event arguments</param>
+        private void MultiFrameArrived( object sender, MultiSourceFrameArrivedEventArgs evt )
+        {
+            var frame = evt.FrameReference.AcquireFrame();
+            if ( frame == null ) return;
+
+            try
+            {
+                if ( BodyFrameEvent != null )
+                {
+                    using ( var bodyFrame = frame.BodyFrameReference.AcquireFrame() )
+                    {
+                        if ( !_firstFrameRelativeTimeEventFired )
+                        {
+                            OnFirstFrameRelativeTimeEvent( bodyFrame.RelativeTime );
+                        }
+                        BodyFrameEvent( bodyFrame );
+                    }
+                }
+                _bodySourceFpsWatcher.Tick();
+                if ( ColorFrameEvent != null )
+                {
+                    using ( var colorFrame = frame.ColorFrameReference.AcquireFrame() )
+                    {
+                        if ( !_firstFrameRelativeTimeEventFired )
+                        {
+                            OnFirstFrameRelativeTimeEvent( colorFrame.RelativeTime );
+                        }
+                        ColorFrameEvent( colorFrame );
+                    }
+                }
+                _colorSourceFpsWatcher.Tick();
+            }
+            catch ( Exception e )
+            {
+                if ( FrameProcessExceptionEvent != null )
+                {
+                    FrameProcessExceptionEvent( e );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handle body frame arrived from dedicated Color frames reader. 
+        /// Send frame to all registered processors and Dispose it.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="evt"></param>
+        private void BodyFrameArrived( object sender, BodyFrameArrivedEventArgs evt )
+        {
+            try
+            {
+                if ( BodyFrameEvent != null )
+                {
+                    using ( var bodyFrame = evt.FrameReference.AcquireFrame() )
+                    {
+                        if ( !_firstFrameRelativeTimeEventFired )
+                        {
+                            OnFirstFrameRelativeTimeEvent( bodyFrame.RelativeTime );
+                        }
+                        BodyFrameEvent( bodyFrame );
+                    }
+                }
+                _bodySourceFpsWatcher.Tick();
+            }
+            catch ( Exception e )
+            {
+                if ( FrameProcessExceptionEvent != null )
+                {
+                    FrameProcessExceptionEvent( e );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handle color frame arrived from dedicated Color frames reader. 
+        /// Send frame to all registered processors and Dispose it.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="evt"></param>
+        private void ColorFrameArrived( object sender, ColorFrameArrivedEventArgs evt )
+        {
+            try
+            {
+                if ( ColorFrameEvent != null )
+                {
+                    using ( var colorFrame = evt.FrameReference.AcquireFrame() )
+                    {
+                        if ( !_firstFrameRelativeTimeEventFired )
+                        {
+                            OnFirstFrameRelativeTimeEvent( colorFrame.RelativeTime );
+                        }
+                        ColorFrameEvent( colorFrame );
+                    }
+                }
+                _colorSourceFpsWatcher.Tick();
+            }
+            catch ( Exception e )
+            {
+                if ( FrameProcessExceptionEvent != null )
+                {
+                    FrameProcessExceptionEvent( e );
+                }
+            }
+        }
+
+        /// <summary>
+        /// Start capture.
+        /// </summary>
+        public void Start()
+        {
+            if ( FrameSync )
+            {
+                // open streams using a synchronized readers, the frame rate is equal to the lowest of each separated stream.
+                // select which streams to enable
+                var features = FrameSourceTypes.None;
+                if ( BodyFrameEvent != null )
+                {
+                    features |= FrameSourceTypes.Body;
+                }
+                if ( ColorFrameEvent != null )
+                {
+                    features |= FrameSourceTypes.Color;
+                }
+                if ( features == FrameSourceTypes.None )
+                {
+                    throw new ApplicationException( "No event processor registered." );
+                }
+                // check reader state
+                if ( _multiFrameReader != null )
+                {
+                    throw new InvalidOperationException( "Kinect already started." );
+                }
+                // open the reader
+                _multiFrameReader = _kinectSensor.OpenMultiSourceFrameReader( features );
+                if ( _multiFrameReader == null )
+                {
+                    Close();
+                    throw new ApplicationException( "Error opening readers." );
+                }
+
+                // register to frames
+                _multiFrameReader.MultiSourceFrameArrived += MultiFrameArrived;
+            }
+            else
+            {
+                // open streams using separate readers, each one with the highest frame rate possible.
+                // open body reader
+                if ( BodyFrameEvent != null )
+                {
+                    if ( _bodyFrameReader != null )
+                    {
+                        throw new InvalidOperationException( "Kinect already started." );
+                    }
+                    _bodyFrameReader = _kinectSensor.BodyFrameSource.OpenReader();
+                    if ( _bodyFrameReader == null )
+                    {
+                        Close();
+                        throw new ApplicationException( "Error opening readers." );
+                    }
+                    _bodyFrameReader.FrameArrived += BodyFrameArrived;
+                }
+                // open color stream reader
+                if ( ColorFrameEvent != null )
+                {
+                    if ( _colorFrameReader != null )
+                    {
+                        throw new InvalidOperationException( "Kinect already started." );
+                    }
+                    _colorFrameReader = _kinectSensor.ColorFrameSource.OpenReader();
+                    if ( _colorFrameReader == null )
+                    {
+                        Close();
+                        throw new ApplicationException( "Error opening readers." );
+                    }
+                    _colorFrameReader.FrameArrived += ColorFrameArrived;
+                }
+            }
+            _firstFrameRelativeTimeEventFired = false;
+            _kinectSensor.Open();
+        }
+
+        /// <summary>
+        /// Close opened reader and sensors.
+        /// </summary>
+        public void Close()
+        {
+            if ( _multiFrameReader != null )
+            {
+                _multiFrameReader.MultiSourceFrameArrived -= MultiFrameArrived;
+                _multiFrameReader.Dispose();
+                _multiFrameReader = null;
+            }
+
+            if ( _colorFrameReader != null )
+            {
+                _colorFrameReader.FrameArrived -= ColorFrameArrived;
+                _colorFrameReader.Dispose();
+                _colorFrameReader = null;
+            }
+
+            if ( _bodyFrameReader != null )
+            {
+                _bodyFrameReader.FrameArrived -= BodyFrameArrived;
+                _bodyFrameReader.Dispose();
+                _bodyFrameReader = null;
+            }
+
+            if (!_kinectUsedExternally)
+            {
+                _kinectSensor?.Close();
+            }
+        }
+    }
+}

--- a/DumpKinectSkeletonLib/Properties/AssemblyInfo.cs
+++ b/DumpKinectSkeletonLib/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DumpKinectSkeletonLib")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DumpKinectSkeletonLib")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a03a0c74-7e96-4baf-80c3-28e1d4cae35e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Windows.Forms;
 using CommandLine;
 using CommandLine.Text;
+using DumpKinectSkeletonLib;
 using Timer = System.Threading.Timer;
 
 namespace DumpKinectSkeleton


### PR DESCRIPTION
Now that the main logic is split into the library project, the library can be utilised within other solutions.

I've also added a second constructor within the KinectSource as to pass in the KinectSensor object, in case it's being used elsewhere.
